### PR TITLE
vingo: add recent scans

### DIFF
--- a/vingo/Cargo.lock
+++ b/vingo/Cargo.lock
@@ -2951,7 +2951,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vingo"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "axum",
  "chrono",
@@ -2960,7 +2960,6 @@ dependencies = [
  "rand",
  "reqwest",
  "sea-orm",
- "sea-query",
  "serde",
  "tokio",
  "tower-http",

--- a/vingo/Cargo.lock
+++ b/vingo/Cargo.lock
@@ -2955,10 +2955,12 @@ version = "1.1.0"
 dependencies = [
  "axum",
  "chrono",
+ "dotenvy",
  "migration",
  "rand",
  "reqwest",
  "sea-orm",
+ "sea-query",
  "serde",
  "tokio",
  "tower-http",

--- a/vingo/Cargo.toml
+++ b/vingo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vingo"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 
 [workspace]
@@ -47,4 +47,3 @@ tracing-subscriber = "=0.3"
 
 migration = { path = "migration" }
 dotenvy = "0.15.7"
-sea-query = { version = "0.32.0", default-features = false}

--- a/vingo/Cargo.toml
+++ b/vingo/Cargo.toml
@@ -46,3 +46,5 @@ tracing = "=0.1"
 tracing-subscriber = "=0.3"
 
 migration = { path = "migration" }
+dotenvy = "0.15.7"
+sea-query = { version = "0.32.0", default-features = false}

--- a/vingo/migration/src/m20240903_194156_create_scan.rs
+++ b/vingo/migration/src/m20240903_194156_create_scan.rs
@@ -8,7 +8,8 @@ pub struct Migration;
 enum Scan {
     Table,
     Id,
-    Time,
+    #[allow(clippy::enum_variant_names)] //TODO: rename ScanTime -> Time
+    ScanTime,
     CardSerial,
 }
 
@@ -22,7 +23,9 @@ impl MigrationTrait for Migration {
                     .table(Scan::Table)
                     .col(pk_auto(Scan::Id))
                     .col(text(Scan::CardSerial))
-                    .col(timestamp_with_time_zone(Scan::Time).default(Expr::current_timestamp()))
+                    .col(
+                        timestamp_with_time_zone(Scan::ScanTime).default(Expr::current_timestamp()),
+                    )
                     .foreign_key(
                         ForeignKey::create()
                             .from(Scan::Table, Scan::CardSerial)

--- a/vingo/src/main.rs
+++ b/vingo/src/main.rs
@@ -45,6 +45,8 @@ struct RegisterState {
 
 #[tokio::main]
 async fn main() {
+    let _ = dotenvy::dotenv();
+
     tracing_subscriber::fmt()
         .with_max_level(tracing::Level::DEBUG)
         .init();

--- a/vingo/src/main.rs
+++ b/vingo/src/main.rs
@@ -103,6 +103,8 @@ fn open_routes() -> Router<AppState> {
         .route("/auth/callback", get(auth::callback))
         .route("/scans", post(scans::add))
         .route("/version", get(info::version))
+        .route("/recent_scans", get(scans::recent))
+        .route("/seasons", get(seasons::get_until_now))
 }
 
 fn authenticated_routes() -> Router<AppState> {
@@ -118,7 +120,6 @@ fn authenticated_routes() -> Router<AppState> {
         )
         .route("/scans", get(scans::get_for_current_user))
         .route("/leaderboard", get(leaderboard::get))
-        .route("/seasons", get(seasons::get_until_now))
         .route("/settings", get(settings::get).patch(settings::update))
         .route_layer(from_fn(middleware::is_logged_in))
 }

--- a/vingo/src/routes/scans.rs
+++ b/vingo/src/routes/scans.rs
@@ -125,14 +125,11 @@ pub async fn recent(state: State<AppState>) -> ResponseResult<Json<Vec<RecentSca
             scan::Column::ScanTime.as_str(),
         )))
         .join(JoinType::InnerJoin, scan::Relation::Card.def())
-        .join(JoinType::InnerJoin, card::Relation::User.def())
         .filter(scan::Column::ScanTime.gt(fourteen_days_ago))
-        .order_by_asc(card::Column::UserId)
         .order_by_asc(Expr::cust(format!(
             "DATE({})",
             scan::Column::ScanTime.as_str()
         )))
-        .order_by_asc(scan::Column::Id)
         .into_model::<RecentScanItem>()
         .all(&state.db)
         .await


### PR DESCRIPTION
- Adds back public available recent (anonymized) scans.
- Makes the seasons (until now) endpoint public. 
  - Can be used for scc for some statistics and it isn't sensitive data.